### PR TITLE
change sequence_number to event_id

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -22,7 +22,7 @@ The root level of an event has the following format:
     aggregate_version [required] :: Integer
     aggregate_id [required] :: String
     aggregate_type [required] :: String
-    sequence_number [required] :: Integer
+    event_id [required] :: String
     name [required] :: String
     server_timestamp [required] :: ISO8601 format String OR language native Date/Time format
     client_timestamp [optional] :: ISO8601 format String OR language native Date/Time format


### PR DESCRIPTION
I like the way www.geteventstore.com uses the event_id as a unique identifier for each event. The sequence_number we are using feels like a implementation detail that has leaked from the `sandthorn_driver_sequel`

More in detail here
http://docs.geteventstore.com/http-api/3.0.1/writing-to-a-stream/
