### PR TITLE
aggregate_version optional

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -19,7 +19,7 @@ A Sandthorn event is a map of keys and values.
 
 The root level of an event has the following format:
 
-    aggregate_version [required] :: Integer
+    aggregate_version [optional] :: Integer
     aggregate_id [required] :: String
     aggregate_type [required] :: String
     sequence_number [required] :: Integer


### PR DESCRIPTION
It would be nice to have the option not to set a aggregate_version number when an event is created on an aggregate. The result would be that no version check is made when the event is stored. It would open up the possibility to have multiple threads doing writes at the same time on the same aggregate not get concurrency errors. It would be ok to not have the latet version of the aggregate loaded but still do writes.
